### PR TITLE
Fix compliance visitor extends bug

### DIFF
--- a/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceVisitor.java
+++ b/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceVisitor.java
@@ -1,7 +1,7 @@
 package com.amazon.checkerframework.compliance.kms;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
-import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.common.value.ValueVisitor;
 
 /**
  * It's necessary to create this class to override the Checker Framework's standard
@@ -17,7 +17,7 @@ import org.checkerframework.common.basetype.BaseTypeVisitor;
  * org.checkerframework.common.basetype.BaseTypeVisitor#createTypeFactory
  * implements the loading mechanism; see its documentation and implementation for more details.
  */
-public class ComplianceVisitor extends BaseTypeVisitor<ComplianceAnnotatedTypeFactory> {
+public class ComplianceVisitor extends ValueVisitor {
     public ComplianceVisitor(BaseTypeChecker checker) {
         super(checker);
     }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This typechecker extends the `ValueChecker` from the Checker Framework, but directly overrides `BaseTypeVisitor` in its own visitor. This causes logic in `ValueVisitor` that ought to be firing to be skipped.

That logic not being present can cause false positive warnings if annotations from the Index Checker are present, which occurs when using the JDK annotations distributed with the Checker Framework (i.e. the `org.checkerframework:jdk8` Maven package).

This change fixes that oversight by making `ComplianceVisitor` directly inherit from `ValueVisitor`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
