### PR TITLE
Update to latest version of the Checker Framework, and other maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ as shown in (https://github.com/awslabs/aws-kms-compliance-checker/blob/master/e
 dependencies {
   ...
   annotationProcessor "software.amazon.checkerframework:aws-kms-compliance-checker:1.0.2"
-  checkerFrameworkAnnotatedJDK "org.checkerframework:jdk8:2.6.0"
-  implementation "org.checkerframework:checker-qual:2.6.0"
+  checkerFrameworkAnnotatedJDK "org.checkerframework:jdk8:3.1.1"
+  implementation "org.checkerframework:checker-qual:3.1.1"
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,10 @@ plugins {
 
 apply plugin: 'java'
 apply plugin: 'maven'
-apply plugin: 'signing'
+
+if (project.hasProperty("signing.keyId")) {
+  apply plugin: 'signing'
+}
 
 sourceCompatibility = 1.8
 group = 'software.amazon.checkerframework'
@@ -21,16 +24,29 @@ repositories {
   mavenCentral()
 }
 
+configurations {
+  // for putting Error Prone javac in bootclasspath for running tests
+  // on Java 8 JDKs
+  errorproneJavac
+}
+
 dependencies {
   testCompile 'com.amazonaws:aws-java-sdk-kms'
   testCompile group: 'junit', name: 'junit', version: '4.12'
-  testCompile group: 'org.checkerframework', name: 'testlib', version: '2.5.4'
-  implementation group: 'org.checkerframework', name: 'checker', version: '2.6.0'
+  testCompile group: 'org.checkerframework', name: 'framework-test', version: '3.1.1'
+  implementation group: 'org.checkerframework', name: 'checker', version: '3.1.1'
+  errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 }
 
 dependencyManagement {
   imports {
-    mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.228'
+    mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.731'
+  }
+}
+
+test {
+  if (!JavaVersion.current().java9Compatible) {
+    jvmArgs "-Xbootclasspath/p:${configurations.errorproneJavac.asPath}"
   }
 }
 
@@ -48,8 +64,10 @@ artifacts {
   archives javadocJar, sourcesJar
 }
 
-signing {
-  sign configurations.archives
+if (project.hasProperty("signing.keyId")) {
+  signing {
+    sign configurations.archives
+  }
 }
 
 uploadArchives {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# These dummy values will be overwritten by your user gradle.properties file
+# if you actually have deploy permissions.
+# The dummy values are here so that the repo will build for a user without
+# credentials.
+ossrhUsername=
+ossrhPassword=

--- a/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceAnnotatedTypeFactory.java
+++ b/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceAnnotatedTypeFactory.java
@@ -2,6 +2,22 @@ package com.amazon.checkerframework.compliance.kms;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
+import org.checkerframework.common.value.qual.ArrayLen;
+import org.checkerframework.common.value.qual.ArrayLenRange;
+import org.checkerframework.common.value.qual.BoolVal;
+import org.checkerframework.common.value.qual.BottomVal;
+import org.checkerframework.common.value.qual.DoubleVal;
+import org.checkerframework.common.value.qual.IntRange;
+import org.checkerframework.common.value.qual.IntRangeFromGTENegativeOne;
+import org.checkerframework.common.value.qual.IntRangeFromNonNegative;
+import org.checkerframework.common.value.qual.IntRangeFromPositive;
+import org.checkerframework.common.value.qual.IntVal;
+import org.checkerframework.common.value.qual.PolyValue;
+import org.checkerframework.common.value.qual.StringVal;
+import org.checkerframework.common.value.qual.UnknownVal;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 /**
  * Empty annotated type factory, in case we ever need one.
@@ -14,5 +30,22 @@ public class ComplianceAnnotatedTypeFactory extends ValueAnnotatedTypeFactory {
     public ComplianceAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
         super.postInit();
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return getBundledTypeQualifiers(ArrayLen.class,
+                ArrayLenRange.class,
+                IntVal.class,
+                IntRange.class,
+                BoolVal.class,
+                StringVal.class,
+                DoubleVal.class,
+                BottomVal.class,
+                UnknownVal.class,
+                IntRangeFromPositive.class,
+                IntRangeFromNonNegative.class,
+                IntRangeFromGTENegativeOne.class,
+                PolyValue.class);
     }
 }

--- a/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceAnnotatedTypeFactory.java
+++ b/src/main/java/com/amazon/checkerframework/compliance/kms/ComplianceAnnotatedTypeFactory.java
@@ -1,54 +1,18 @@
 package com.amazon.checkerframework.compliance.kms;
 
-import com.sun.source.tree.MemberSelectTree;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
-import org.checkerframework.framework.type.AnnotatedTypeMirror;
-import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
-import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
-
-import java.util.Collections;
 
 /**
- * Adds new type introduction rules to give specific type annotations to DataKeySpec
- * enums.
+ * Empty annotated type factory, in case we ever need one.
+ *
+ * Used to handle defaulting for enums until https://github.com/typetools/checker-framework/issues/2147
+ * was fixed.
  */
 public class ComplianceAnnotatedTypeFactory extends ValueAnnotatedTypeFactory {
 
     public ComplianceAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
         super.postInit();
-    }
-
-    @Override
-    public TreeAnnotator createTreeAnnotator() {
-        return new ListTreeAnnotator(
-                new ComplianceTreeAnnotator(this), super.createTreeAnnotator());
-    }
-
-    /**
-     * The tree annotator is responsible for placing default annotations on trees.
-     */
-    private class ComplianceTreeAnnotator extends TreeAnnotator {
-
-        private static final String DATA_KEY_SPEC = "com.amazonaws.services.kms.model.DataKeySpec";
-
-        ComplianceTreeAnnotator(ComplianceAnnotatedTypeFactory typeFactory) {
-            super(typeFactory);
-        }
-
-        /**
-         * The type of a value of the DataKeySpec enum is a StringVal with a
-         * value equal to the name of the member. So, for example, DataKeySpec.AES_256's
-         * type is @StringVal("AES_256").
-         */
-        @Override
-        public Void visitMemberSelect(MemberSelectTree tree, AnnotatedTypeMirror type) {
-            if (DATA_KEY_SPEC.equals(getAnnotatedType(tree.getExpression()).getUnderlyingType().toString())) {
-                String identifier = tree.getIdentifier().toString();
-                type.replaceAnnotation(createStringAnnotation(Collections.singletonList(identifier)));
-            }
-            return super.visitMemberSelect(tree, type);
-        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
The purpose of this PR is to bring this repository up-to-date with the latest version of the Checker Framework. The changes are relatively minimal - the only interesting thing is the need to include a copy of ErrorProne's javac compiler if running the tests on a Java 8 JVM.

Since this repo was last updated, https://github.com/typetools/checker-framework/issues/2147 has been fixed. That meant that I could delete the workaround in `ComplianceAnnotatedTypeFactory` for that problem - the annotations on enums in the stub files are now be sufficient. The KMS stub isn't committed to this repo (for legal reasons, I assume?), but you can remove the comment above the definition of `DataKeySpec` that refers to that issue, too.

I also cleaned up the repo a bit so that it's possible to build the code and run the tests without signing/deployment keys, which should definitely be possible.

Finally, I updated to the latest versions of Gradle (for building) and the AWS SDK (for testing).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
