### PR TITLE
Use Gradle version 6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ configurations {
 }
 
 dependencies {
-  testCompile 'com.amazonaws:aws-java-sdk-kms'
-  testCompile group: 'junit', name: 'junit', version: '4.12'
-  testCompile group: 'org.checkerframework', name: 'framework-test', version: '3.1.1'
+  testImplementation 'com.amazonaws:aws-java-sdk-kms'
+  testImplementation group: 'junit', name: 'junit', version: '4.12'
+  testImplementation group: 'org.checkerframework', name: 'framework-test', version: '3.1.1'
   implementation group: 'org.checkerframework', name: 'checker', version: '3.1.1'
   errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
   implementation "com.google.errorprone:javac:9+181-r4173-1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Description of changes:*
Use Gradle version 6.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
