### PR TITLE
Use `plugins` block rather than `apply plugin:`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,10 @@
 // we'll just use the UI. An automatic solution would be nice.
 
 plugins {
+  id 'java'
+  id 'maven' // TODO: 'maven' plugin is deprecated, use 'maven-publish' instead
   id 'io.spring.dependency-management' version '1.0.7.RELEASE'
 }
-
-apply plugin: 'java'
-apply plugin: 'maven'
 
 sourceCompatibility = 1.8
 group = 'software.amazon.checkerframework'


### PR DESCRIPTION
*Description of changes:*
Use `plugins` block rather than `apply plugin:`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
